### PR TITLE
Add minimum version check for gfortran.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Minimum CMake version.
 cmake_minimum_required (VERSION 2.8.12)
 
+set(GFORTRAN_MINIMUM_VERSION "5.3.0")
+
 # Adjust CMake's module path.
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
@@ -101,6 +103,9 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SYS_FLAGS}")
 
 # Fortran compiler flags.
 if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS ${GFORTRAN_MINIMUM_VERSION})
+    message(FATAL_ERROR "The gfortran compiler version must be greater than ${GFORTRAN_MINIMUM_VERSION}. You have: ${CMAKE_Fortran_COMPILER_VERSION}.")
+  endif()
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -W -Wall -std=gnu -pedantic -Wno-unused-variable -Wno-unused-parameter -Werror=use-without-only -DCPRGNU")
 endif()
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,37 @@ Jinyun Tang, jinyuntang@lbl.gov
 
 ## Building
 
+### Requirements
+
+Requirements for configuring and building BeTR:
+
+* fortran compiler
+
+  * gfortran > 5.3.0. Older versions make work, but are not
+    supported. At a minimum, you will have to change the compiler
+    flags. The pfunit testing frame work can NOT be build with gcc <
+    4.9.
+
+  * intel - TBD
+
+  * pgi - TBD
+
+  * nag - TBD
+
+* c compiler - only used for 3rd-party libraries. Any modern compiler
+  should work. The following versions are tested:
+
+  * clang - approximately 7.3
+
+  * gcc - 5.3
+
+* python 2.7
+
+All third party dependancies for building and running standalone BeTR
+will eventually be included in the 3rd-party directory.
+
+### Build
+
 BeTR uses a cmake based build system. The default build is debug. To
 build using the default debug configuration:
 
@@ -33,6 +64,10 @@ To build a release configuration of the code:
 The following command will create local/bin/, where sbetr will be installed.
 
     make install
+
+Please note, the top level make file providing `make config` etc is a
+convenience for the most common use cases. You don't have to use it
+and can specify all configuration and build commands manually.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ where Xyz is the build configuration.
 
 The standalone `sbetr` executable is in:
 
-    ${SBETR_(ROOT}/bulid/Xyz-Debug/src/driver/sbetr
+    ${SBETR_(ROOT}/build/Xyz-Debug/src/driver/sbetr
 
 To build a release configuration of the code:
 


### PR DESCRIPTION
Start documenting configuration and build dependancies. Add minimum
version check for gfortran.

Testing:
    configure and build - OS X, gfortran 5.3.0
    unit tests - pass
    regression tests - pass
    meta tests - pass