### PR TITLE
Fix line length issues caused by __FILE__ macro

### DIFF
--- a/src/betr/betr_core/BeTRTracerType.F90
+++ b/src/betr/betr_core/BeTRTracerType.F90
@@ -13,7 +13,8 @@ module BeTRTracerType
   !
   implicit none
   private
-  character(len=*), parameter :: mod_filename = __FILE__
+  character(len=*), parameter :: mod_filename = &
+       __FILE__
 
   !----------------------------------------------------
   !betr tracer setup structure

--- a/src/betr/betr_core/TracerParamsMod.F90
+++ b/src/betr/betr_core/TracerParamsMod.F90
@@ -34,7 +34,8 @@ module TracerParamsMod
   public :: calc_aerecond
   public :: betr_annualupdate
   !parameters
-  character(len=*), parameter :: filename = __FILE__
+  character(len=*), parameter :: filename = &
+       __FILE__
   real(r8), parameter         :: minval_diffus = 1.e-20_r8   !minimum diffusivity, m2/s
   real(r8), parameter         :: minval_airvol = 1.e-10_r8   !minimum air-filled volume
 

--- a/src/betr/betr_main/BetrBGCMod.F90
+++ b/src/betr/betr_main/BetrBGCMod.F90
@@ -37,7 +37,8 @@ module BetrBGCMod
   real(r8), parameter :: tiny_val         = 1.e-20_r8 !very small value, for tracer concentration etc.
   real(r8), parameter :: dtime_min        = 1._r8     !minimum time step 1 second
   real(r8), parameter :: err_tol_transp   = 1.e-8_r8  !error tolerance for tracer transport
-  character(len =*), parameter :: filename= __FILE__
+  character(len=*), parameter :: filename = &
+       __FILE__
 
   public :: stage_tracer_transport
   public :: surface_tracer_hydropath_update

--- a/src/betr/betr_math/FindRootMod.F90
+++ b/src/betr/betr_math/FindRootMod.F90
@@ -12,6 +12,9 @@ module FindRootMod
   use MathfuncMod   , only : is_bounded
 
   implicit none
+
+  character(len=*), parameter :: mod_filename = &
+       __FILE__
   
 contains
   !-------------------------------------------------------------------------------
@@ -42,12 +45,12 @@ contains
              return
           else
              write(iulog,*)'no bounded solution for the given quadratic equation'
-             call endrun(msg=errmsg(__FILE__, __LINE__))
+             call endrun(msg=errmsg(mod_filename, __LINE__))
           endif
        endif
     else
        write(iulog,*)'no real solution for the given quadratic equation'
-       call endrun(msg=errmsg(__FILE__, __LINE__))
+       call endrun(msg=errmsg(mod_filename, __LINE__))
     endif
     return
   end function quadrootbnd
@@ -73,7 +76,7 @@ contains
        x = (-b + sqrt(delta))/2._r8
     else
        write(iulog,*)'no positive solution for the given quadratic equation'
-       call endrun(msg=errmsg(__FILE__, __LINE__))
+       call endrun(msg=errmsg(mod_filename, __LINE__))
     endif
     return
   end function quadproot
@@ -109,7 +112,7 @@ contains
     delta =-4._r8 * p**3._r8 - 27._r8 * q ** 2._r8
     if(delta<0._r8)then
        write(iulog,*)'no real solution for the given cubic equation'
-       call endrun(msg=errmsg(__FILE__, __LINE__))
+       call endrun(msg=errmsg(mod_filename, __LINE__))
     else
        n = sqrt(-4._r8*p/3._r8)
        f = -q/2._r8 * (-p/3._r8)**(-1.5_r8)
@@ -131,7 +134,7 @@ contains
                 return
              else
                 write(iulog,*)'no bounded solution for the given cubic equation'
-                call endrun(msg=errmsg(__FILE__, __LINE__))
+                call endrun(msg=errmsg(mod_filename, __LINE__))
              endif
           endif
        endif
@@ -165,7 +168,7 @@ contains
     delta =-4._r8 * p**3._r8 - 27._r8 * q ** 2._r8
     if(delta<0._r8)then
        write(iulog,*)'no real solution for the given cubic equation'
-       call endrun(msg=errmsg(__FILE__, __LINE__))
+       call endrun(msg=errmsg(mod_filename, __LINE__))
     else
        n = sqrt(-4._r8*p/3._r8)
        f = -q/2._r8 * (-p/3._r8)**(-1.5_r8)
@@ -393,7 +396,7 @@ contains
     if((fa > 0._r8 .and. fb > 0._r8).or.(fa < 0._r8 .and. fb < 0._r8))then
        write(iulog,*) 'root must be bracketed for brent'
        write(iulog,*) 'a=',a,' b=',b,' fa=',fa,' fb=',fb
-       call endrun(msg=errmsg(__FILE__, __LINE__))
+       call endrun(msg=errmsg(mod_filename, __LINE__))
     endif
     c=b
     fc=fb

--- a/src/betr/betr_rxns/ReactionsFactory.F90
+++ b/src/betr/betr_rxns/ReactionsFactory.F90
@@ -15,6 +15,9 @@ module ReactionsFactory
   use PlantSoilBGCMod , only : plant_soilbgc_type
   implicit none
 
+  character(len=*), parameter :: mod_filename = &
+       __FILE__
+  
   private
 
   public :: create_betr_def_application
@@ -66,7 +69,7 @@ contains
        allocate(bgc_reaction, source=bgc_reaction_h2oiso_type())
     case default
        write(iulog,*)subname //' ERROR: unknown method: ', method
-       call endrun(msg=errMsg(__FILE__, __LINE__))
+       call endrun(msg=errMsg(mod_filename, __LINE__))
     end select
   end function create_bgc_reaction_type
   !-------------------------------------------------------------------------------
@@ -94,7 +97,7 @@ contains
      allocate(plant_soilbgc, source=plant_soilbgc_h2oiso_run_type())
   case default
      write(*, *)subname //' ERROR: unknown method: ', method
-     call endrun(msg=errMsg(__FILE__, __LINE__))
+     call endrun(msg=errMsg(mod_filename, __LINE__))
   end select
 
   end function create_plant_soilbgc_type

--- a/src/betr/betr_util/bshr_log_mod.F90
+++ b/src/betr/betr_util/bshr_log_mod.F90
@@ -17,6 +17,10 @@ module bshr_log_mod
   use bshr_kind_mod, only : SHR_KIND_CX
 
   implicit none
+
+  character(len=*), parameter :: mod_filename = &
+       __FILE__
+
   private
 
 ! !PUBLIC TYPES:
@@ -48,7 +52,7 @@ contains
 ! !DESCRIPTION:
 !     Return an error message containing file & line info
 !     \newline
-!     errMsg = shr\_log\_errMsg(__FILE__, __LINE__)
+!     errMsg = shr\_log\_errMsg(mod_filename, __LINE__)
 !
 ! !REVISION HISTORY:
 !     2013-July-23 - Bill Sacks

--- a/src/betr/betr_util/bshr_string_mod.F90
+++ b/src/betr/betr_util/bshr_string_mod.F90
@@ -1728,7 +1728,8 @@ function shr_string_listCreateField( numFields, strBase ) result ( retString )
    character(*),parameter :: subName = "(shr_string_listCreateField) "
    character(*),parameter :: F00     = "('(shr_string_listCreateField) ',a) "
 
-   character(*), parameter :: file_name = __FILE__
+   character(*), parameter :: file_name = &
+        __FILE__
 
 !-------------------------------------------------------------------------------
 

--- a/src/driver/BeTRType.F90
+++ b/src/driver/BeTRType.F90
@@ -35,7 +35,8 @@ module BetrType
 
   private
 
-  character(len=*), parameter :: filename = __FILE__
+  character(len=*), parameter :: filename = &
+       __FILE__
 
   type, public :: betr_type
      ! namelist control variables

--- a/src/driver/sbetrDriverMod.F90
+++ b/src/driver/sbetrDriverMod.F90
@@ -11,7 +11,9 @@ module sbetrDriverMod
   private
   save
   public :: sbetrBGC_driver
-  character(len=*), parameter :: mod_filename = __FILE__
+
+  character(len=*), parameter :: mod_filename = &
+       __FILE__
 
 contains
 

--- a/src/shr/shr_string_mod.F90
+++ b/src/shr/shr_string_mod.F90
@@ -1723,7 +1723,8 @@ function shr_string_listCreateField( numFields, strBase ) result ( retString )
    character(*),parameter :: subName = "(shr_string_listCreateField) "
    character(*),parameter :: F00     = "('(shr_string_listCreateField) ',a) "
 
-   character(*), parameter :: file_name = __FILE__
+   character(*), parameter :: file_name = &
+        __FILE__
 
 !-------------------------------------------------------------------------------
 

--- a/src/stub_clm/CNSharedParamsMod.F90
+++ b/src/stub_clm/CNSharedParamsMod.F90
@@ -6,7 +6,8 @@ module CNSharedParamsMod
   use shr_kind_mod , only: r8 => shr_kind_r8
   implicit none
   save
-
+  character(len=*), parameter :: mod_filename = &
+       __FILE__
   ! CNParamsShareInst.  PGI wants the type decl. public but the instance
   ! is indeed protected.  A generic private statement at the start of the module
   ! overrides the protected functionality with PGI
@@ -52,43 +53,43 @@ contains
     !
     tString='q10_mr'
     !call ncd_io(varname=trim(tString),data=tempr, flag='read', ncid=ncid, readvar=readv)
-    !if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
+    !if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(mod_filename, __LINE__))
     CNParamsShareInst%Q10=tempr
 
     tString='minpsi_hr'
     !call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
-    !if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
+    !if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(mod_filename, __LINE__))
     CNParamsShareInst%minpsi=tempr
 
     tString='cwd_fcel'
     !call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
-    !if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
+    !if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(mod_filename, __LINE__))
     CNParamsShareInst%cwd_fcel=tempr
 
     tString='cwd_flig'
     !call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
-    !if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
+    !if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(mod_filename, __LINE__))
     CNParamsShareInst%cwd_flig=tempr
 
     tString='froz_q10'
     !call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
-    !if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
+    !if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(mod_filename, __LINE__))
     CNParamsShareInst%froz_q10=tempr
 
     tString='decomp_depth_efolding'
     !call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
-    !if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
+    !if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(mod_filename, __LINE__))
     CNParamsShareInst%decomp_depth_efolding=tempr
 
     tString='mino2lim'
     !call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
-    !if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
+    !if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(mod_filename, __LINE__))
     CNParamsShareInst%mino2lim=tempr
     !CNParamsShareInst%mino2lim=0.2_r8
 
     tString='organic_max'
     !call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
-    !if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
+    !if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(mod_filename, __LINE__))
     CNParamsShareInst%organic_max=tempr
 
   end subroutine CNParamsReadShared

--- a/src/stub_clm/column_varcon.F90
+++ b/src/stub_clm/column_varcon.F90
@@ -50,7 +50,8 @@ contains
     ! !LOCAL VARIABLES:
 
     character(len=*), parameter :: subname = 'icemec_class_to_col_itype'
-    character(len=*), parameter :: mod_filename = __FILE__
+    character(len=*), parameter :: mod_filename = &
+         __FILE__
     !-----------------------------------------------------------------------
     SHR_ASSERT((1 <= icemec_class .and. icemec_class <= maxpatch_glcmec), errMsg(mod_filename, __LINE__))
 
@@ -75,7 +76,8 @@ contains
     ! !LOCAL VARIABLES:
 
     character(len=*), parameter :: subname = 'col_itype_to_icemec_class'
-    character(len=*), parameter :: mod_filename = __FILE__
+    character(len=*), parameter :: mod_filename = 'column_varcon.F90'
+
     !-----------------------------------------------------------------------
 
     icemec_class = col_itype - istice_mec*100

--- a/src/stub_clm/ncdio_pio.F90
+++ b/src/stub_clm/ncdio_pio.F90
@@ -23,6 +23,10 @@ module ncdio_pio
   use clm_varctl  , only : single_column, iulog
   use spmdMod     , only : masterproc
   implicit none
+
+  character(len=*), parameter :: mod_filename = &
+       __FILE__
+
   private
   save
 
@@ -245,7 +249,7 @@ module ncdio_pio
     write (iulog,*) 'CHECK_DIM error: mismatch of input dimension ',dimlen, &
       ' with expected value ',value,' for variable ', trim(dimname)
 
-    call shr_sys_abort(errMsg(__FILE__,__LINE__))
+    call shr_sys_abort(errMsg(mod_filename,__LINE__))
   end if
 
   end subroutine check_dim
@@ -1348,7 +1352,7 @@ module ncdio_pio
 
     if (ni == 0 .or. nj == 0) then
        write(iulog,*) trim(subname),' ERROR: ni,nj = ',ni,nj,' cannot be zero '
-       call shr_sys_abort(errMsg(__FILE__, __LINE__))
+       call shr_sys_abort(errMsg(mod_filename, __LINE__))
     end if
 
     if (nj == 1) then

--- a/src/stub_clm/soilorder_varcon.F90
+++ b/src/stub_clm/soilorder_varcon.F90
@@ -48,7 +48,8 @@ module soilorder_varcon
   real(r8), pointer :: k_s3_biochem(:)
   real(r8), pointer :: k_s4_biochem(:)
 
-  character(len=*), parameter :: mod_filename = __FILE__
+  character(len=*), parameter :: mod_filename = &
+       __FILE__
 
 
   ! !PUBLIC MEMBER FUNCTIONS:

--- a/src/stub_clm/subgridAveMod.F90
+++ b/src/stub_clm/subgridAveMod.F90
@@ -62,7 +62,8 @@ module subgridAveMod
   private :: build_scale_l2g
   private :: create_scale_l2g_lookup
 
-  character(len=*), parameter :: mod_filename = __FILE__
+  character(len=*), parameter :: mod_filename = &
+       __FILE__
   
   ! WJS (10-14-11): TODO:
   !


### PR DESCRIPTION
Travis-CI builds are failing in the primary betr repo because of line
length issues caused by the __FILE__ macros interacting with the long
path for that build. Just blanket replacing them with a filename
parameter and putting the __FILE__ macro on it's own line.

Testing:
    configure and build - os x, gfortran 5.3
    unit tests - pass
    regression tests - pass
    meta tests - pass