### PR TITLE
Fixes dummy shr_mpi_initialized subroutine

### DIFF
--- a/src/betr/betr_util/bshr_mpi_mod.F90
+++ b/src/betr/betr_util/bshr_mpi_mod.F90
@@ -1609,8 +1609,11 @@ SUBROUTINE shr_mpi_initialized(flag,string)
 !-------------------------------------------------------------------------------
 ! PURPOSE: MPI initialized
 !-------------------------------------------------------------------------------
-   if (len(string) > 0) continue
-   if (flag) continue
+
+   if (present(string)) then
+      if (len(string) > 0) continue
+   endif
+   flag = .true.
 
 
 END SUBROUTINE shr_mpi_initialized


### PR DESCRIPTION
- Checks if the optional input argument (string)
  is present.
- Sets a value for the output argument