### PR TITLE
Rework 'make test'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,29 @@ define run-config
 @cd $(BUILDDIR) && cmake $(CURDIR) $(CONFIG_FLAGS)
 endef
 
-all test clean install:
+all: 
+	@if [ ! -f $(BUILDDIR)/Makefile ]; then \
+		more INSTALL; \
+	else \
+		$(MAKE) -C $(BUILDDIR) $@ --no-print-directory $(MAKEFLAGS); \
+	fi
+
+install: all
+	@if [ ! -f $(BUILDDIR)/Makefile ]; then \
+		more INSTALL; \
+	else \
+		$(MAKE) -C $(BUILDDIR) $@ --no-print-directory $(MAKEFLAGS); \
+	fi
+
+test: install
+	@if [ ! -f $(BUILDDIR)/Makefile ]; then \
+		more INSTALL; \
+	else \
+		$(MAKE) -C $(BUILDDIR) $@ --no-print-directory $(MAKEFLAGS); \
+		$(MAKE) -C regression-tests $@ --no-print-directory $(MAKEFLAGS); \
+	fi
+
+clean:
 	@if [ ! -f $(BUILDDIR)/Makefile ]; then \
 		more INSTALL; \
 	else \
@@ -144,4 +166,4 @@ ctags-emacs :
 #dist:
 #	utils/mkdist.sh $(PKGNAME)
 
-.PHONY: config distclean all clean install uninstall
+.PHONY: config distclean all clean install uninstall test

--- a/regression-tests/Makefile
+++ b/regression-tests/Makefile
@@ -9,7 +9,9 @@ RTEST_ARGS += --executable $(SBETR)
 COVERAGERC = --rcfile mtest/.coveragerc
 COVERAGE_RUN_FLAGS = $(COVERAGERC) -m unittest discover
 
-test rtest : FORCE
+test : mtest rtest
+
+rtest : FORCE
 	$(RTEST) $(RTEST_ARGS)
 
 # NOTE(bja, 201603) rcheck - runs the regression test manager with
@@ -22,15 +24,24 @@ rcheck : FORCE
 mtest : FORCE
 	python -m unittest discover --buffer --start-directory mtest/unit/
 
+# NOTE(bja, 201605) python coverage tool must be installed. If it
+# isn't in the system packages, run 'make env'.
 test-coverage : FORCE
 	coverage erase
-	COVERAGE_FILE=.coverage.unit coverage run $(COVERAGE_RUN_FLAGS) mtest/unit
-	COVERAGE_FILE=.coverage.xfail coverage run $(COVERAGE_RUN_FLAGS) mtest/xfail
+	PATH="${PATH}:../local/bin" COVERAGE_FILE=.coverage.unit coverage run $(COVERAGE_RUN_FLAGS) mtest/unit
+	PATH="${PATH}:../local/bin" COVERAGE_FILE=.coverage.xfail coverage run $(COVERAGE_RUN_FLAGS) mtest/xfail
 	coverage combine $(COVERAGERC)
 	coverage html $(COVERAGERC)
 	coverage report $(COVERAGERC)
 	@echo 'For detailed analysis, see the html report at:'
 	@echo '    coverage-html/index.html'
+
+# NOTE(bja, 201605) this creates the python virtual environment and
+# install the code coverage tool. Requires virtualenv be
+# installed at the system level.
+env : 
+	virtualenv env
+	. env/bin/activate; pip install coverage
 
 clean : FORCE
 	-find . -name '*~' -print0 | xargs -0 rm

--- a/regression-tests/rtest_betr.py
+++ b/regression-tests/rtest_betr.py
@@ -918,7 +918,7 @@ def verify_executable(executable):
 
     """
     logging.info(SEPERATOR)
-    logging.info('Using executable:')
+    logging.info('Verifying executable:')
     logging.info('    {0}'.format(executable))
 
     if not os.path.isfile(executable):
@@ -1020,12 +1020,27 @@ def find_executable(exe, paths):
             verify_executable(full_path)
         except RuntimeError as e:
             # not useable, move on
+            logging.info('    checked : "{0}"'.format(full_path))
             pass
         else:
             found = True
             break
+
     if not found:
-        msg = "ERROR: could not find a usable executable for '{0}'".format(exe)
+        # check to see if it is just in the user path.
+        try:
+            command = [exe, '--help']
+            subprocess.call(command, shell=False)
+        except OSError:
+            # not in path:
+            pass
+        else:
+            full_path = exe
+            found = True
+
+    if not found:
+        msg = ("ERROR: could not find a usable executable for '{0}' in:\n"
+               "    {1}".format(exe, paths))
         raise RuntimeError(msg)
     logging.info('  Using "{0}" at :\n    {1}'.format(exe, full_path))
     return full_path


### PR DESCRIPTION
Rework how 'make test' runs. Now the entire build, install, unit test,
regression test cycle can be run with 'make config test' and 'make test'.
Fix a minor bug in regression test driver that didn't pick up ncgen when
it was in the path. Add make rule to create virtualenv and install
python coverage tool for code coverage in the regression test driver.

Testing:
    configure and build - os x, gfortran 5.3
    unit tests - pass
    regression tests - pass
    meta tests - pass