### PR TITLE
add root respiration as part of input

### DIFF
--- a/src/driver/standalone/BeTRSimulationStandalone.F90
+++ b/src/driver/standalone/BeTRSimulationStandalone.F90
@@ -255,7 +255,17 @@ contains
   type(canopystate_type)                 , optional, intent(in) :: canopystate_vars
   type(chemstate_type)                   , optional, intent(in) :: chemstate_vars
   type(soilstate_type)                   , optional, intent(in) :: soilstate_vars
+  integer :: j, c, c_l
 
+  if(present(carbonflux_vars))then
+    c_l=1
+    do j = 1, betr_nlevsoi
+      do c = bounds%begc, bounds%endc
+        if(.not. this%active_col(c))cycle
+        this%biophys_forc(c)%c12flx%rt_vr_col(c_l,j) = carbonflux_vars%rr_vr_col(c,j)
+      enddo
+    enddo
+  endif
   call this%BeTRSetBiophysForcing(bounds, col, pft, 1, nlevsoi, carbonflux_vars, waterstate_vars, &
       waterflux_vars, temperature_vars, soilhydrology_vars, atm2lnd_vars, canopystate_vars, &
       chemstate_vars, soilstate_vars)

--- a/src/stub_clm/CNCarbonFluxType.F90
+++ b/src/stub_clm/CNCarbonFluxType.F90
@@ -96,6 +96,7 @@ contains
     begp = bounds%begp; endp= bounds%endp
     begc = bounds%begc; endc= bounds%endc
 
+
     allocate(this%rr_col                  (begc:endc)) ; this%rr_col      (:)  = nan
     allocate(this%rr_patch                (begp:endp)) ; this%rr_patch    (:)  = nan
     allocate(this%tempavg_agnpp_patch(begp:endp)); this%tempavg_agnpp_patch(:) = spval
@@ -130,7 +131,7 @@ contains
     allocate(this%fire_mortality_c_to_cwdc_col (begc:endc,1:nlevdecomp_full)); this%fire_mortality_c_to_cwdc_col (:,:) = spval
     allocate(this%phenology_c_to_litr_lig_c_col(begc:endc,1:nlevdecomp_full)); this%phenology_c_to_litr_lig_c_col(:,:) = spval
     allocate(this%som_c_leached_col(begc:endc)); this%som_c_leached_col(:) = spval
-
+    allocate(this%rr_vr_col(begc:endc,1:nlevdecomp_full)); this%rr_vr_col(:,:) = spval
     allocate(this%cflx_input_litr_met_vr_col(begc:endc,1:nlevdecomp_full)); this%cflx_input_litr_met_vr_col(:,:) = spval
     allocate(this%cflx_input_litr_cel_vr_col(begc:endc,1:nlevdecomp_full)); this%cflx_input_litr_cel_vr_col(:,:) = spval
     allocate(this%cflx_input_litr_lig_vr_col(begc:endc,1:nlevdecomp_full)); this%cflx_input_litr_lig_vr_col(:,:) = spval


### PR DESCRIPTION
Now root autotrophic respiration can be
added as an optional input to drive the bgc model.
All tests passed with gnu 8.x compilers.