### PR TITLE
Change interface declaration in ODEMod.F90 for gfortran-10 compatibility

### DIFF
--- a/src/betr/betr_math/ODEMod.F90
+++ b/src/betr/betr_math/ODEMod.F90
@@ -26,6 +26,37 @@ module ODEMod
   public :: get_rerr
 
 
+  abstract interface
+     subroutine odebbks(extra,y0,dt,t,nprimeq,neq,f)
+        use bshr_kind_mod , only : r8 => shr_kind_r8
+        use gbetrType     , only : gbetr_type
+        implicit none
+        class(gbetr_type), intent(inout) :: extra
+        real(r8)         , intent(in)    :: y0(neq)
+        real(r8)         , intent(in)    :: t
+        real(r8)         , intent(in)    :: dt
+        integer          , intent(in)    :: nprimeq
+        integer          , intent(in)    :: neq
+        real(r8)         , intent(out)   :: f(neq)
+     end subroutine odebbks
+  end interface
+
+
+  abstract interface
+     subroutine oderkx(extra,y0,dt,t,neq,f)
+        use bshr_kind_mod , only : r8 => shr_kind_r8
+        use gbetrType     , only : gbetr_type
+        implicit none
+        class(gbetr_type), target        :: extra
+        real(r8)         , intent(in)    :: y0(neq)
+        real(r8)         , intent(in)    :: t
+        real(r8)         , intent(in)    :: dt
+        integer          , intent(in)    :: neq
+        real(r8)         , intent(out)   :: f(neq)
+     end subroutine oderkx
+  end interface
+
+
   interface get_rerr
      module procedure get_rerr_v
      module procedure get_rerr_s
@@ -50,7 +81,7 @@ contains
     real(r8),           intent(in)  :: dt      !time step
     real(r8),           intent(out) :: y(neq)  !return values
     real(r8), optional, intent(out) :: pscal   !scaling factor
-    external :: odefun
+    procedure(odebbks) :: odefun
 
     ! !LOCAL VARIABLES:
     real(r8) :: f(neq)
@@ -77,7 +108,7 @@ contains
     real(r8), intent(in)  :: dt         !time step
     real(r8), intent(out) :: y(neq)     !return value
 
-    external :: odefun
+    procedure(odebbks) :: odefun
     ! !LOCAL VARIABLES:
     real(r8) :: f(neq)
     real(r8) :: f1(neq)
@@ -111,7 +142,7 @@ contains
     real(r8), optional, intent(out) :: pscal
     type(betr_status_type), intent(out) :: bstatus
 
-    external :: odefun
+    procedure(odebbks) :: odefun
 
     ! !LOCAL VARIABLES:
     real(r8) :: f(neq)
@@ -169,7 +200,7 @@ contains
     real(r8), intent(in)  :: dt
     real(r8), intent(out) :: y(neq)
     type(betr_status_type), intent(out) :: bstatus
-    external :: odefun
+    procedure(odebbks) :: odefun
 
     ! !LOCAL VARIABLES:
     real(r8) :: f(neq)
@@ -298,7 +329,7 @@ contains
     integer,  intent(in)  :: nprimeq  !
     real(r8), intent(out) :: y(neq)   ! updated state variable
     type(betr_status_type), intent(out) :: bstatus
-    external :: odefun
+    procedure(odebbks) :: odefun
 
     ! !LOCAL VARIABLES:
     real(r8) :: yc(neq)    !coarse time stepping solution
@@ -546,7 +577,7 @@ contains
     real(r8) :: kt(neq)
     real(r8) :: ti, dt05, a
     integer :: n
-    external :: odefun
+    procedure(oderkx) :: odefun
 
     ti = t
     dt05 = dt * 0.5_r8
@@ -611,7 +642,7 @@ contains
     real(r8) :: k2(neq)
     real(r8) :: ti, dt05
     integer :: n
-    external :: odefun
+    procedure(oderkx) :: odefun
 
     ti = t
     dt05 = dt * 0.5_r8
@@ -645,7 +676,7 @@ contains
     real(r8), intent(in)  :: dt       ! time stepping
     integer,  intent(in)  :: nprimeq  !
     real(r8), intent(out) :: y(neq)   ! updated state variable
-    external :: odefun
+    procedure(odebbks) :: odefun
 
     ! !LOCAL VARIABLES:
     real(r8) :: yc(neq)    !coarse time stepping solution


### PR DESCRIPTION
Add a few abstract interfaces (odebbks and oderkx), and replaced "external" declarations with "procedure(odexxx)" ones, so the code could compile with gfortran-10.  These changes should be [BFB] and address [E3SM issue 4151](https://github.com/E3SM-Project/E3SM/issues/4151).