### PR TITLE
Add IBM compiler build fixes for OLCF Summit and Ascent

### DIFF
--- a/src/betr/betr_math/ODEMod.F90
+++ b/src/betr/betr_math/ODEMod.F90
@@ -760,7 +760,6 @@ contains
     real(r8), intent(in)  :: dt       ! time stepping
     integer,  intent(in)  :: nprimeq  !
     real(r8), intent(out) :: y(neq)   ! updated state variable
-    external :: odefun
     interface
       subroutine odefun(extra, y, dt2, tt, nprimeq, neq, f)
       use bshr_kind_mod , only : r8 => shr_kind_r8

--- a/src/betr/betr_util/betr_time_mod.F90
+++ b/src/betr/betr_util/betr_time_mod.F90
@@ -431,7 +431,7 @@ contains
   character(len=*), intent(out) :: ymdhs
 
   write(ymdhs,'(I4.4,I2.2,I2.2,I2.2,I4.4)')this%cyears,this%moy,this%dom,&
-     int(this%tod/3600.0),int(mod(this%tod,3600.0))
+     int(this%tod/3600.0),int(mod(this%tod,3600._r8))
   end subroutine get_ymdhs
   !-------------------------------------------------------------------------------
   function its_a_new_hour(this)result(yesno)
@@ -440,7 +440,7 @@ contains
   logical :: yesno
 
 
-  yesno= abs(mod(this%tod, 3600.0))<1.e-3_r8
+  yesno= abs(mod(this%tod, 3600._r8))<1.e-3_r8
 
   end function its_a_new_hour
 
@@ -452,7 +452,7 @@ contains
   logical :: yesno
 
 
-  yesno= abs(mod(this%tod, 86400.0))<1.e-3_r8
+  yesno= abs(mod(this%tod, 86400._r8))<1.e-3_r8
 
   end function its_a_new_day
 


### PR DESCRIPTION
These are needed by E3SM for IBM compiler runs.

Addresses E3SM-Project/E3SM#5036

[BFB]