### PR TITLE
remove redundant print message

### DIFF
--- a/src/driver/shared/BeTRSimulation.F90
+++ b/src/driver/shared/BeTRSimulation.F90
@@ -2268,7 +2268,6 @@ contains
       enddo
       this%betr_pft(c)%npfts = pp
       this%betr_pft(c)%crop(0:betr_maxpft)=crop(0:betr_maxpft)
-      print*,'crop',size(crop),betr_maxpatch_pft,col%npfts(c), this%betr_pft(c)%npfts
     endif
   enddo
 


### PR DESCRIPTION
This avoids unnecessary write out to log file.